### PR TITLE
PHP 7.0: invalid numeric literal error due to invalid octal number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_script:
 
 script:
   - phpunit --coverage-text
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ before_script:
 
 script:
   - phpunit --coverage-text
-  

--- a/tests/Moontoast/Math/BigNumberTest.php
+++ b/tests/Moontoast/Math/BigNumberTest.php
@@ -619,7 +619,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     {
         $fromBase = array(2, 8, 10, 16, 36);
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($toBase as $to) {
@@ -643,7 +643,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -685,7 +685,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10NegativeNumbers()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(-10, -27, -39, -039, -0x5F, '-10', '-27', '-39');
+        $convertValues = array(-10, -27, -39, -037, -0x5F, '-10', '-27', '-39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -707,7 +707,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertToBase10()
     {
         $fromBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($convertValues as $val) {


### PR DESCRIPTION
Original pull request: https://github.com/moontoast/math/pull/6

----

When you try to run `composer install` on a PHP 7.0.0 (stable) machine, you will get an error along the lines of

```
Parse error: Invalid numeric literal in /home/vagrant/git/math/tests/Moontoast/Math/BigNumberTest.php on line 622
```

Having a look at line 622, you'll see this:

```php
$convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
```

and using Google for above error you immediately find [PHP bug #70193](https://bugs.php.net/bug.php?id=70193) and there's this explanation:

> Numbers starting with 0 are octal literals. 08 is not a valid octal literal, so you get an error now. Previously it was silently treated like 0.

which really makes sense.

Obviously, the problem is the "octal" (as interpreted by PHP) value `039` which is in fact not octal (`9` isn't a valid octal digit). I changed `039` and `-039` to `037` and `-037`, respectively, and now there are now more syntax errors and the [tests pass](https://travis-ci.org/limenet/math).

I hope you didn't choose `039` because it *might* produce an unexpected result when converting bases and changing it to `037` doesn't somehow make it "easier" to pass the tests.

What do you think?

(*Note: the "bump" commit was to trigger Travis CI*)