### PR TITLE
php 7.0 unit tests fixes - correct octal numbers

### DIFF
--- a/tests/Moontoast/Math/BigNumberTest.php
+++ b/tests/Moontoast/Math/BigNumberTest.php
@@ -619,7 +619,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     {
         $fromBase = array(2, 8, 10, 16, 36);
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($toBase as $to) {
@@ -643,7 +643,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -685,7 +685,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertFromBase10NegativeNumbers()
     {
         $toBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(-10, -27, -39, -039, -0x5F, '-10', '-27', '-39');
+        $convertValues = array(-10, -27, -39, -037, -0x5F, '-10', '-27', '-39');
 
         foreach ($toBase as $to) {
             foreach ($convertValues as $val) {
@@ -707,7 +707,7 @@ class BigNumberTest extends \PHPUnit_Framework_TestCase
     public function testConvertToBase10()
     {
         $fromBase = array(2, 8, 10, 16, 36);
-        $convertValues = array(10, 27, 39, 039, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
+        $convertValues = array(10, 27, 39, 037, 0x5F, '10', '27', '39', '5F', '5f', '3XYZ', '3xyz', '5f$@');
 
         foreach ($fromBase as $from) {
             foreach ($convertValues as $val) {


### PR DESCRIPTION
Unit tests fail on php7 with the following error:
```
PHP Parse error:  Invalid numeric literal in /home/alex/work/math/tests/Moontoast/Math/BigNumberTest.php on line 622
```