### PR TITLE
BC safe immutables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,25 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - nightly
-  - hhvm
-
 matrix:
+  fast_finish: true
   allow_failures:
     - php: nightly
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env:
+        - TEST_COVERAGE=true
+    - php: nightly
+    - php: hhvm
 
 sudo: false
 
 before_install:
-  - travis_retry composer self-update
+  - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini ; fi
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist
@@ -31,4 +33,4 @@ script:
   - ./vendor/bin/phpcs src tests --standard=psr2 -sp
 
 after_script:
-  - php vendor/bin/coveralls
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls ; fi

--- a/src/Moontoast/Math/AbstractBigNumber.php
+++ b/src/Moontoast/Math/AbstractBigNumber.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Moontoast\Math;
+
+abstract class AbstractBigNumber implements BigNumberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEqualTo($number)
+    {
+        return ($this->compareTo($number) === 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isGreaterThan($number)
+    {
+        return ($this->compareTo($number) === 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isGreaterThanOrEqualTo($number)
+    {
+        return ($this->compareTo($number) >= 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLessThan($number)
+    {
+        return ($this->compareTo($number) === -1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLessThanOrEqualTo($number)
+    {
+        return ($this->compareTo($number) <= 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNegative()
+    {
+        return ($this->signum() === -1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPositive()
+    {
+        return ($this->signum() === 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function signum()
+    {
+        if ($this->isGreaterThan(0)) {
+            return 1;
+        } elseif ($this->isLessThan(0)) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Converts a number between arbitrary bases (from 2 to 36)
+     *
+     * @param string|int $number The number to convert
+     * @param int $fromBase (optional) The base $number is in; defaults to 10
+     * @param int $toBase (optional) The base to convert $number to; defaults to 16
+     * @return string
+     */
+    public static function baseConvert($number, $fromBase = 10, $toBase = 16)
+    {
+        $number = self::convertToBase10($number, $fromBase);
+
+        return self::convertFromBase10($number, $toBase);
+    }
+
+    /**
+     * Converts a base-10 number to an arbitrary base (from 2 to 36)
+     *
+     * @param string|int $number The number to convert
+     * @param int $toBase The base to convert $number to
+     * @return string
+     * @throws \InvalidArgumentException if $toBase is outside the range 2 to 36
+     */
+    public static function convertFromBase10($number, $toBase)
+    {
+        if ($toBase < 2 || $toBase > 36) {
+            throw new \InvalidArgumentException("Invalid `to base' ({$toBase})");
+        }
+
+        $bn = new static($number);
+        $number = $bn->abs()->getValue();
+        $chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+        $outNumber = '';
+
+        while (bccomp($number, $toBase) >= 0) {
+            $remainder = bcmod($number, $toBase);
+            $number = bcdiv($number, $toBase, 0);
+            $outNumber = $chars[(int) $remainder] . $outNumber;
+        }
+
+        return $chars[(int) $number] . $outNumber;
+    }
+
+    /**
+     * Converts a number from an arbitrary base (from 2 to 36) to base 10
+     *
+     * @param string|int $number The number to convert
+     * @param int $fromBase The base $number is in
+     * @return string
+     * @throws \InvalidArgumentException if $fromBase is outside the range 2 to 36
+     */
+    public static function convertToBase10($number, $fromBase)
+    {
+        if ($fromBase < 2 || $fromBase > 36) {
+            throw new \InvalidArgumentException("Invalid `from base' ({$fromBase})");
+        }
+
+        $number = (string) $number;
+        $len = strlen($number);
+        $base10Num = '0';
+
+        for ($i = $len; $i > 0; $i--) {
+            $c = ord($number[$len - $i]);
+
+            if ($c >= ord('0') && $c <= ord('9')) {
+                $c -= ord('0');
+            } elseif ($c >= ord('A') && $c <= ord('Z')) {
+                $c -= ord('A') - 10;
+            } elseif ($c >= ord('a') && $c <= ord('z')) {
+                $c -= ord('a') - 10;
+            } else {
+                continue;
+            }
+
+            if ($c >= $fromBase) {
+                continue;
+            }
+
+            $base10Num = bcadd(bcmul($base10Num, $fromBase, 0), (string) $c, 0);
+        }
+
+        return $base10Num;
+    }
+
+    /**
+     * Changes the default scale used by all Binary Calculator functions
+     *
+     * @param int $scale
+     * @return void
+     */
+    public static function setDefaultScale($scale)
+    {
+        ini_set('bcmath.scale', $scale);
+    }
+}

--- a/src/Moontoast/Math/BigNumber.php
+++ b/src/Moontoast/Math/BigNumber.php
@@ -27,7 +27,7 @@ namespace Moontoast\Math;
  *
  * @link http://www.php.net/bcmath
  */
-class BigNumber
+class BigNumber extends AbstractBigNumber
 {
     /**
      * Number value, as a string
@@ -260,86 +260,6 @@ class BigNumber
     }
 
     /**
-     * Returns true if the current number equals the given number
-     *
-     * @param mixed $number May be of any type that can be cast to a string
-     *                      representation of a base 10 number
-     * @return bool
-     */
-    public function isEqualTo($number)
-    {
-        return ($this->compareTo($number) == 0);
-    }
-
-    /**
-     * Returns true if the current number is greater than the given number
-     *
-     * @param mixed $number May be of any type that can be cast to a string
-     *                      representation of a base 10 number
-     * @return bool
-     */
-    public function isGreaterThan($number)
-    {
-        return ($this->compareTo($number) == 1);
-    }
-
-    /**
-     * Returns true if the current number is greater than or equal to the given number
-     *
-     * @param mixed $number May be of any type that can be cast to a string
-     *                      representation of a base 10 number
-     * @return bool
-     */
-    public function isGreaterThanOrEqualTo($number)
-    {
-        return ($this->compareTo($number) >= 0);
-    }
-
-    /**
-     * Returns true if the current number is less than the given number
-     *
-     * @param mixed $number May be of any type that can be cast to a string
-     *                      representation of a base 10 number
-     * @return bool
-     */
-    public function isLessThan($number)
-    {
-        return ($this->compareTo($number) == -1);
-    }
-
-    /**
-     * Returns true if the current number is less than or equal to the given number
-     *
-     * @param mixed $number May be of any type that can be cast to a string
-     *                      representation of a base 10 number
-     * @return bool
-     */
-    public function isLessThanOrEqualTo($number)
-    {
-        return ($this->compareTo($number) <= 0);
-    }
-
-    /**
-     * Returns true if the current number is a negative number
-     *
-     * @return bool
-     */
-    public function isNegative()
-    {
-        return ($this->signum() == -1);
-    }
-
-    /**
-     * Returns true if the current number is a positive number
-     *
-     * @return bool
-     */
-    public function isPositive()
-    {
-        return ($this->signum() == 1);
-    }
-
-    /**
      * Finds the modulus of the current number divided by the given number
      *
      * @param mixed $number May be of any type that can be cast to a string
@@ -547,22 +467,6 @@ class BigNumber
     }
 
     /**
-     * Returns the sign (signum) of the current number
-     *
-     * @return int -1, 0 or 1 as the value of this BigNumber is negative, zero or positive
-     */
-    public function signum()
-    {
-        if ($this->isGreaterThan(0)) {
-            return 1;
-        } elseif ($this->isLessThan(0)) {
-            return -1;
-        }
-
-        return 0;
-    }
-
-    /**
      * Finds the square root of the current number
      *
      * @return BigNumber for fluent interface
@@ -610,100 +514,5 @@ class BigNumber
             FILTER_SANITIZE_NUMBER_FLOAT,
             FILTER_FLAG_ALLOW_FRACTION
         );
-    }
-
-    /**
-     * Converts a number between arbitrary bases (from 2 to 36)
-     *
-     * @param string|int $number The number to convert
-     * @param int $fromBase (optional) The base $number is in; defaults to 10
-     * @param int $toBase (optional) The base to convert $number to; defaults to 16
-     * @return string
-     */
-    public static function baseConvert($number, $fromBase = 10, $toBase = 16)
-    {
-        $number = self::convertToBase10($number, $fromBase);
-
-        return self::convertFromBase10($number, $toBase);
-    }
-
-    /**
-     * Converts a base-10 number to an arbitrary base (from 2 to 36)
-     *
-     * @param string|int $number The number to convert
-     * @param int $toBase The base to convert $number to
-     * @return string
-     * @throws \InvalidArgumentException if $toBase is outside the range 2 to 36
-     */
-    public static function convertFromBase10($number, $toBase)
-    {
-        if ($toBase < 2 || $toBase > 36) {
-            throw new \InvalidArgumentException("Invalid `to base' ({$toBase})");
-        }
-
-        $bn = new self($number);
-        $number = $bn->abs()->getValue();
-        $chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-        $outNumber = '';
-        
-        while (bccomp($number, $toBase) >= 0) {
-            $remainder = bcmod($number, $toBase);
-            $number = bcdiv($number, $toBase, 0);
-            $outNumber = $chars[(int) $remainder] . $outNumber;
-        }
-
-        return $chars[(int) $number] . $outNumber;
-    }
-
-    /**
-     * Converts a number from an arbitrary base (from 2 to 36) to base 10
-     *
-     * @param string|int $number The number to convert
-     * @param int $fromBase The base $number is in
-     * @return string
-     * @throws \InvalidArgumentException if $fromBase is outside the range 2 to 36
-     */
-    public static function convertToBase10($number, $fromBase)
-    {
-        if ($fromBase < 2 || $fromBase > 36) {
-            throw new \InvalidArgumentException("Invalid `from base' ({$fromBase})");
-        }
-
-        $number = (string) $number;
-        $len = strlen($number);
-        $base10Num = '0';
-
-        for ($i = $len; $i > 0; $i--) {
-            $c = ord($number[$len - $i]);
-
-            if ($c >= ord('0') && $c <= ord('9')) {
-                $c -= ord('0');
-            } elseif ($c >= ord('A') && $c <= ord('Z')) {
-                $c -= ord('A') - 10;
-            } elseif ($c >= ord('a') && $c <= ord('z')) {
-                $c -= ord('a') - 10;
-            } else {
-                continue;
-            }
-
-            if ($c >= $fromBase) {
-                continue;
-            }
-
-            $base10Num = bcadd(bcmul($base10Num, $fromBase, 0), (string) $c, 0);
-        }
-
-        return $base10Num;
-    }
-
-    /**
-     * Changes the default scale used by all Binary Calculator functions
-     *
-     * @param int $scale
-     * @return void
-     */
-    public static function setDefaultScale($scale)
-    {
-        ini_set('bcmath.scale', $scale);
     }
 }

--- a/src/Moontoast/Math/BigNumberImmutable.php
+++ b/src/Moontoast/Math/BigNumberImmutable.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Moontoast\Math;
+
+class BigNumberImmutable extends AbstractBigNumber
+{
+    /**
+     * @var BigNumber
+     */
+    protected $bigNumber;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($bigNumber, $scale = null)
+    {
+        if ($scale === null && $bigNumber instanceof BigNumberInterface) {
+            $scale = $bigNumber->getScale();
+        }
+
+        $bigNumber = new BigNumber($bigNumber, $scale);
+
+        if ($scale === 0) {
+            $bigNumber->setScale($scale);
+            $bigNumber->setValue($bigNumber->getValue());
+        }
+
+        $this->bigNumber = $bigNumber;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->bigNumber->__toString();
+    }
+
+    public function __clone()
+    {
+        $this->bigNumber = clone $this->bigNumber;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function abs()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->abs();
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->add($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ceil()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->ceil();
+
+        return new static($newBigNumber, 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compareTo($number)
+    {
+        return $this->bigNumber->compareTo($number);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToBase($base)
+    {
+        return $this->bigNumber->convertToBase($base);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decrement()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->decrement();
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function divide($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->divide($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function floor()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->floor();
+
+        return new static($newBigNumber, 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScale()
+    {
+        return $this->bigNumber->getScale();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return $this->bigNumber->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->increment();
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mod($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->mod($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function multiply($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->multiply($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negate()
+    {
+        return $this->multiply(-1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pow($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->pow($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function powMod($pow, $mod)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->powMod($pow, $mod);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function round()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->round();
+        $newBigNumber->setScale(0);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shiftLeft($bits)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->shiftLeft($bits);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shiftRight($bits)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->shiftRight($bits);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sqrt()
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->sqrt();
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function subtract($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->subtract($number);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * Sets the scale of this BigNumber
+     *
+     * @param int $scale Specifies the default number of digits after the decimal
+     *                   place to be used in operations for this BigNumber
+     * @return BigNumberImmutable   returns a new instance
+     */
+    public function withScale($scale)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->setScale($scale);
+
+        return new static($newBigNumber);
+    }
+
+    /**
+     * Sets the value of this BigNumber to a new value
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     * @return BigNumberImmutable   returns a new instance
+     */
+    public function withValue($number)
+    {
+        $newBigNumber = clone $this->bigNumber;
+        $newBigNumber->setValue($number);
+
+        return new static($newBigNumber);
+    }
+}

--- a/src/Moontoast/Math/BigNumberImmutable.php
+++ b/src/Moontoast/Math/BigNumberImmutable.php
@@ -39,11 +39,6 @@ class BigNumberImmutable extends AbstractBigNumber
         return $this->bigNumber->__toString();
     }
 
-    public function __clone()
-    {
-        $this->bigNumber = clone $this->bigNumber;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Moontoast/Math/BigNumberInterface.php
+++ b/src/Moontoast/Math/BigNumberInterface.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Moontoast\Math;
+
+/**
+ * Represents a number for use with Binary Calculator computations
+ *
+ * @link http://www.php.net/bcmath
+ */
+interface BigNumberInterface
+{
+    /**
+     * Returns the string value of this BigNumber
+     *
+     * @return string String representation of the number in base 10
+     */
+    public function __toString();
+
+    /**
+     * Sets the current number to the absolute value of itself
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function abs();
+
+    /**
+     * Adds the given number to the current number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/bcadd
+     */
+    public function add($number);
+
+    /**
+     * Finds the next highest integer value by rounding up the current number
+     * if necessary
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/ceil
+     */
+    public function ceil();
+
+    /**
+     * Compares the current number with the given number
+     *
+     * Returns 0 if the two operands are equal, 1 if the current number is
+     * larger than the given number, -1 otherwise.
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return int
+     * @link http://www.php.net/bccomp
+     */
+    public function compareTo($number);
+
+    /**
+     * Returns the current value converted to an arbitrary base
+     *
+     * @param int $base The base to convert the current number to
+     *
+     * @return string String representation of the number in the given base
+     */
+    public function convertToBase($base);
+
+    /**
+     * Decreases the value of the current number by one
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function decrement();
+
+    /**
+     * Divides the current number by the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @throws Exception\ArithmeticException if $number is zero
+     * @link http://www.php.net/bcdiv
+     */
+    public function divide($number);
+
+    /**
+     * Finds the next lowest integer value by rounding down the current number
+     * if necessary
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/floor
+     */
+    public function floor();
+
+    /**
+     * Returns the scale used for this BigNumber
+     *
+     * If no scale was set, this will default to the value of bcmath.scale
+     * in php.ini.
+     *
+     * @return int
+     */
+    public function getScale();
+
+    /**
+     * Returns the current raw value of this BigNumber
+     *
+     * @return string String representation of the number in base 10
+     */
+    public function getValue();
+
+    /**
+     * Increases the value of the current number by one
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function increment();
+
+    /**
+     * Returns true if the current number equals the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return bool
+     */
+    public function isEqualTo($number);
+
+    /**
+     * Returns true if the current number is greater than the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return bool
+     */
+    public function isGreaterThan($number);
+
+    /**
+     * Returns true if the current number is greater than or equal to the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return bool
+     */
+    public function isGreaterThanOrEqualTo($number);
+
+    /**
+     * Returns true if the current number is less than the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return bool
+     */
+    public function isLessThan($number);
+
+    /**
+     * Returns true if the current number is less than or equal to the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return bool
+     */
+    public function isLessThanOrEqualTo($number);
+
+    /**
+     * Returns true if the current number is a negative number
+     *
+     * @return bool
+     */
+    public function isNegative();
+
+    /**
+     * Returns true if the current number is a positive number
+     *
+     * @return bool
+     */
+    public function isPositive();
+
+    /**
+     * Finds the modulus of the current number divided by the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @throws Exception\ArithmeticException if $number is zero
+     * @link http://www.php.net/bcmod
+     */
+    public function mod($number);
+
+    /**
+     * Multiplies the current number by the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/bcmul
+     */
+    public function multiply($number);
+
+    /**
+     * Sets the current number to the negative value of itself
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function negate();
+
+    /**
+     * Raises current number to the given number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/bcpow
+     */
+    public function pow($number);
+
+    /**
+     * Raises the current number to the $pow, then divides by the $mod
+     * to find the modulus
+     *
+     * This is functionally equivalent to the following code:
+     *
+     * <code>
+     *     $n = new BigNumber(1234);
+     *     $n->mod($n->pow(32), 2);
+     * </code>
+     *
+     * However, it uses bcpowmod(), so it is faster and can accept larger
+     * parameters.
+     *
+     * @param mixed $pow May be of any type that can be cast to a string
+     *                   representation of a base 10 number
+     * @param mixed $mod May be of any type that can be cast to a string
+     *                   representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @throws Exception\ArithmeticException if $number is zero
+     * @link http://www.php.net/bcpowmod
+     */
+    public function powMod($pow, $mod);
+
+    /**
+     * Rounds the current number to the nearest integer
+     *
+     * @return BigNumberInterface for fluent interface
+     * @todo Implement precision digits
+     */
+    public function round();
+
+    /**
+     * Shifts the current number $bits to the left
+     *
+     * @param int $bits
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function shiftLeft($bits);
+
+    /**
+     * Shifts the current number $bits to the right
+     *
+     * @param int $bits
+     *
+     * @return BigNumberInterface for fluent interface
+     */
+    public function shiftRight($bits);
+
+    /**
+     * Returns the sign (signum) of the current number
+     *
+     * @return int -1, 0 or 1 as the value of this BigNumber is negative, zero or positive
+     */
+    public function signum();
+
+    /**
+     * Finds the square root of the current number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/bcsqrt
+     */
+    public function sqrt();
+
+    /**
+     * Subtracts the given number from the current number
+     *
+     * @param mixed $number May be of any type that can be cast to a string
+     *                      representation of a base 10 number
+     *
+     * @return BigNumberInterface for fluent interface
+     * @link http://www.php.net/bcsub
+     */
+    public function subtract($number);
+}

--- a/tests/Moontoast/Math/BigNumberImmutableTest.php
+++ b/tests/Moontoast/Math/BigNumberImmutableTest.php
@@ -558,14 +558,21 @@ class BigNumberImmutableImmutableTest extends TestCase
     {
         $bn = new BigNumberImmutable(1);
 
-        $this->assertSame($bn, $bn->shiftLeft(30));
-        $this->assertSame('1073741824', $bn->getValue());
-        $this->assertSame('4611686018427387904', $bn->shiftLeft(32)->getValue());
-        $this->assertSame('42535295865117307932921825928971026432', $bn->shiftLeft(63)->getValue());
-        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn->shiftLeft(64)->getValue());
+        $bn2 = $bn->shiftLeft(30);
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('1073741824', $bn2->getValue());
+        $bn3 = $bn2->shiftLeft(32);
+        $this->assertSame('4611686018427387904', $bn3->getValue());
+
+        $bn4 = $bn3->shiftLeft(63);
+        $this->assertSame('42535295865117307932921825928971026432', $bn4->getValue());
+
+        $bn5 = $bn4->shiftLeft(64);
+        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn5->getValue());
+
         $this->assertSame(
             '3369993333393829974333376885877453834204643052817571560137951281152',
-            $bn->shiftLeft(32)->getValue()
+            $bn5->shiftLeft(32)->getValue()
         );
     }
 
@@ -576,12 +583,13 @@ class BigNumberImmutableImmutableTest extends TestCase
     {
         $bn = new BigNumberImmutable('3369993333393829974333376885877453834204643052817571560137951281152');
 
-        $this->assertSame($bn, $bn->shiftRight(32));
-        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn->getValue());
-        $this->assertSame('42535295865117307932921825928971026432', $bn->shiftRight(64)->getValue());
-        $this->assertSame('4611686018427387904', $bn->shiftRight(63)->getValue());
-        $this->assertSame('1073741824', $bn->shiftRight(32)->getValue());
-        $this->assertSame('1', $bn->shiftRight(30)->getValue());
+        $bn2 = $bn->shiftRight(32);
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn2->getValue());
+        $this->assertSame('42535295865117307932921825928971026432', $bn2->shiftRight(64)->getValue());
+        $this->assertSame('4611686018427387904', $bn2->shiftRight(64)->shiftRight(63)->getValue());
+        $this->assertSame('1073741824', $bn2->shiftRight(64)->shiftRight(63)->shiftRight(32)->getValue());
+        $this->assertSame('1', $bn2->shiftRight(64)->shiftRight(63)->shiftRight(32)->shiftRight(30)->getValue());
     }
 
     /**
@@ -591,13 +599,12 @@ class BigNumberImmutableImmutableTest extends TestCase
     {
         $bn1 = new BigNumberImmutable(16);
         $bn2 = new BigNumberImmutable(17);
-        $bn3 = clone $bn2;
 
-        $this->assertSame($bn1, $bn1->sqrt());
-        $this->assertSame('4', $bn1->getValue());
+        $this->assertNotSame($bn1, $bn1->sqrt());
+        $this->assertSame('4', $bn1->sqrt()->getValue());
         $this->assertSame('4', $bn2->sqrt()->getValue());
 
-        $bn3->setScale(8);
+        $bn3 = $bn2->withScale(8);
         $this->assertSame('4.12310562', $bn3->sqrt()->getValue());
     }
 
@@ -608,10 +615,11 @@ class BigNumberImmutableImmutableTest extends TestCase
     {
         $bn = new BigNumberImmutable(2147483647);
 
-        $this->assertSame($bn, $bn->subtract('9223372036854775808'));
-        $this->assertSame('-9223372034707292161', $bn->getValue());
+        $bn2 = $bn->subtract('9223372036854775808');
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('-9223372034707292161', $bn2->getValue());
 
-        $bn->setScale(3);
-        $this->assertSame('-9223372034707292163.250', $bn->subtract(2.25)->getValue());
+        $bn3 = $bn2->withScale(3);
+        $this->assertSame('-9223372034707292163.250', $bn3->subtract(2.25)->getValue());
     }
 }

--- a/tests/Moontoast/Math/BigNumberImmutableTest.php
+++ b/tests/Moontoast/Math/BigNumberImmutableTest.php
@@ -1,0 +1,617 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Moontoast\Math;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class BigNumberImmutableImmutableTest extends TestCase
+{
+    protected function setUp()
+    {
+        ini_set('bcmath.scale', 0);
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::__construct
+     * @covers \Moontoast\Math\BigNumberImmutable::getValue
+     * @covers \Moontoast\Math\BigNumberImmutable::getScale
+     * @covers \Moontoast\Math\BigNumberImmutable::getScale
+     */
+    public function testConstruct()
+    {
+        $bn1 = new BigNumberImmutable('9,223,372,036,854,775,808');
+        $this->assertSame('9223372036854775808', $bn1->getValue());
+        $this->assertEquals(0, $bn1->getScale());
+
+        $bn2 = new BigNumberImmutable(2147483647);
+        $this->assertSame('2147483647', $bn2->getValue());
+        $this->assertEquals(0, $bn2->getScale());
+
+        $bn3 = new BigNumberImmutable($bn1, 4);
+        $this->assertSame('9223372036854775808.0000', $bn3->getValue());
+        $this->assertEquals(4, $bn3->getScale());
+
+        $bn4 = new BigNumberImmutable('9223372036854775808.12345678901', 5);
+        $this->assertSame('9223372036854775808.12345', $bn4->getValue());
+        $this->assertEquals(5, $bn4->getScale());
+
+        BigNumberImmutable::setDefaultScale(2);
+        $bn5 = new BigNumberImmutable(2147483647);
+        $this->assertSame('2147483647.00', $bn5->getValue());
+        $this->assertEquals(2, $bn5->getScale());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::withScale
+     */
+    public function testWithScale()
+    {
+        ini_set('bcmath.scale', 5);
+
+        $bn = new BigNumberImmutable('9223372036854775808.12345');
+
+        $bn2 = $bn->withScale(2);
+        $this->assertSame('9223372036854775808.12', $bn2->getValue());
+        $this->assertSame(2, $bn2->getScale());
+
+        $bn3 = $bn->withScale(0);
+        $this->assertSame('9223372036854775808', $bn3->getValue());
+        $this->assertSame(0, $bn3->getScale());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::withValue
+     */
+    public function testWithValue()
+    {
+        $bn = new BigNumberImmutable(1);
+        $bn2 = $bn->withValue(1234.657);
+
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('1234', $bn2->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::__toString
+     * @covers \Moontoast\Math\BigNumberImmutable::getValue
+     */
+    public function testToString()
+    {
+        $bn = new BigNumberImmutable(2147483647);
+        $this->assertSame('2147483647', (string) $bn);
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::abs
+     */
+    public function testAbs()
+    {
+        $bn1 = new BigNumberImmutable('-1234.5678', 4);
+        $bn2 = new BigNumberImmutable('5678');
+        $bn3 = new BigNumberImmutable('0');
+
+        $this->assertSame('1234.5678', $bn1->abs()->getValue());
+        $this->assertSame('5678', $bn2->abs()->getValue());
+        $this->assertSame('0', $bn3->abs()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::add
+     */
+    public function testAdd()
+    {
+        $bn = new BigNumberImmutable(2147483647);
+        $bn2 = $bn->add('9223372036854775808');
+
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('9223372039002259455', $bn2->getValue());
+
+        $bn3 = $bn2->withScale(3);
+        $this->assertNotSame($bn3, $bn2);
+        $this->assertSame('9223372039002259457.250', $bn3->add(2.25)->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::ceil
+     */
+    public function testCeil()
+    {
+        $bn1 = new BigNumberImmutable('4.3', 1);
+        $bn2 = new BigNumberImmutable('9.999', 3);
+        $bn3 = new BigNumberImmutable('-3.14', 2);
+        $bn4 = new BigNumberImmutable('23.00000000000000999999', 20);
+        $bn5 = new BigNumberImmutable('23.00000000000001999999', 20);
+        $bn6 = new BigNumberImmutable('-23.00000000000000999999', 20);
+        $bn7 = new BigNumberImmutable('-23.00000000000001999999', 20);
+
+        $this->assertSame('5', $bn1->ceil()->getValue());
+        $this->assertSame('10', $bn2->ceil()->getValue());
+        $this->assertSame('-3', $bn3->ceil()->getValue());
+        $this->assertSame('23', $bn4->ceil()->getValue());
+        $this->assertSame('24', $bn5->ceil()->getValue());
+        $this->assertSame('-23', $bn6->ceil()->getValue());
+        $this->assertSame('-23', $bn7->ceil()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::compareTo
+     */
+    public function testCompareTo()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808');
+        $bn2 = new BigNumberImmutable(2147483647);
+
+        $this->assertEquals(0, $bn1->compareTo('9223372036854775808'));
+        $this->assertEquals(0, $bn2->compareTo(2147483647));
+        $this->assertEquals(1, $bn1->compareTo($bn2));
+        $this->assertEquals(-1, $bn2->compareTo($bn1));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::convertToBase
+     */
+    public function testConvertToBase()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775807');
+        $bn2 = new BigNumberImmutable('9223372036854775810');
+        $bn3 = new BigNumberImmutable('2');
+
+        $this->assertEquals('7fffffffffffffff', $bn1->convertToBase(16));
+        $this->assertEquals('8000000000000002', $bn2->convertToBase(16));
+        $this->assertEquals('10', $bn3->convertToBase(2));
+        $this->assertEquals('1y2p0ij32e8e7', $bn1->convertToBase(36));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::decrement
+     */
+    public function testDecrement()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $bn2 = $bn->decrement();
+
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('9223372036854775807', $bn2->getValue());
+
+        $bn3 = $bn2->withScale(4);
+        $this->assertSame('9223372036854775806.0000', $bn3->decrement()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::divide
+     */
+    public function testDivide()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $bn2 = $bn->divide(2);
+
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('4611686018427387904', $bn2->getValue());
+
+        $bn3 = $bn2->withScale(5);
+        $this->assertSame('1537228672809129301.33333', $bn3->divide(3)->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::divide
+     * @expectedException Moontoast\Math\Exception\ArithmeticException
+     * @expectedExceptionMessage Division by zero
+     */
+    public function testDivideByZero()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $bn->divide(0);
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::floor
+     */
+    public function testFloor()
+    {
+        $bn1 = new BigNumberImmutable('4.3', 1);
+        $bn2 = new BigNumberImmutable('9.999', 3);
+        $bn3 = new BigNumberImmutable('-3.14', 2);
+        $bn4 = new BigNumberImmutable('23.00000000000000999999', 20);
+        $bn5 = new BigNumberImmutable('23.00000000000001999999', 20);
+        $bn6 = new BigNumberImmutable('-23.00000000000000999999', 20);
+        $bn7 = new BigNumberImmutable('-23.00000000000001999999', 20);
+
+        $this->assertSame('4', $bn1->floor()->getValue());
+        $this->assertSame('9', $bn2->floor()->getValue());
+        $this->assertSame('-4', $bn3->floor()->getValue());
+        $this->assertSame('23', $bn4->floor()->getValue());
+        $this->assertSame('23', $bn5->floor()->getValue());
+        $this->assertSame('-23', $bn6->floor()->getValue());
+        $this->assertSame('-24', $bn7->floor()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::getScale
+     */
+    public function testGetScale()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808');
+        $bn2 = new BigNumberImmutable(2147483647, 20);
+
+        $this->assertEquals(0, $bn1->getScale());
+        $this->assertEquals(20, $bn2->getScale());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::getValue
+     */
+    public function testGetValue()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808');
+        $bn2 = new BigNumberImmutable(2147483647, 20);
+
+        $this->assertSame('9223372036854775808', $bn1->getValue());
+        $this->assertSame('2147483647.00000000000000000000', $bn2->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::increment
+     */
+    public function testIncrement()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $bn2 = $bn->increment();
+
+        $this->assertNotSame($bn, $bn2);
+        $this->assertSame('9223372036854775809', $bn2->getValue());
+
+        $bn3 = $bn2->withScale(3);
+        $this->assertSame('9223372036854775810.000', $bn3->increment()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isEqualTo
+     */
+    public function testIsEqualTo()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.123456', 6);
+        $bn2 = new BigNumberImmutable('9223372036854775808.123461', 6);
+
+        $this->assertFalse($bn1->isEqualTo($bn2));
+
+        $bn3 = $bn1->withScale(4);
+        $bn4 = $bn2->withScale(4);
+        $this->assertTrue($bn3->isEqualTo($bn4));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isGreaterThan
+     */
+    public function testIsGreaterThan()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.123456', 6);
+        $bn2 = new BigNumberImmutable('9223372036854775808.123461', 6);
+
+        $this->assertTrue($bn2->isGreaterThan($bn1));
+        $this->assertFalse($bn1->isGreaterThan($bn2));
+
+        $bn3 = $bn2->withScale(4);
+        $this->assertFalse($bn3->isGreaterThan($bn1));
+
+        $bn4 = $bn1->withScale(4);
+        $this->assertFalse($bn4->isGreaterThan($bn2));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isGreaterThanOrEqualTo
+     */
+    public function testIsGreaterThanOrEqualTo()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.123456', 6);
+        $bn2 = new BigNumberImmutable('9223372036854775808.123461', 6);
+
+        $this->assertTrue($bn2->isGreaterThanOrEqualTo($bn1));
+        $this->assertFalse($bn1->isGreaterThanOrEqualTo($bn2));
+
+        $bn3 = $bn2->withScale(4);
+        $this->assertTrue($bn3->isGreaterThanOrEqualTo($bn1));
+
+        $bn4 = $bn1->withScale(4);
+        $this->assertTrue($bn4->isGreaterThanOrEqualTo($bn2));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isLessThan
+     */
+    public function testIsLessThan()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.123456', 6);
+        $bn2 = new BigNumberImmutable('9223372036854775808.123461', 6);
+
+        $this->assertTrue($bn1->isLessThan($bn2));
+        $this->assertFalse($bn2->isLessThan($bn1));
+
+        $bn3 = $bn1->withScale(4);
+        $this->assertFalse($bn3->isLessThan($bn2));
+
+        $bn4 = $bn2->withScale(4);
+        $this->assertFalse($bn4->isLessThan($bn1));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isLessThanOrEqualTo
+     */
+    public function testIsLessThanOrEqualTo()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.123456', 6);
+        $bn2 = new BigNumberImmutable('9223372036854775808.123461', 6);
+
+        $this->assertTrue($bn1->isLessThanOrEqualTo($bn2));
+        $this->assertFalse($bn2->isLessThanOrEqualTo($bn1));
+
+        $bn3 = $bn1->withScale(4);
+        $this->assertTrue($bn3->isLessThanOrEqualTo($bn2));
+
+        $bn4 = $bn2->withScale(4);
+        $this->assertTrue($bn4->isLessThanOrEqualTo($bn1));
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isNegative
+     */
+    public function testIsNegative()
+    {
+        $bn1 = new BigNumberImmutable(1234);
+        $bn2 = new BigNumberImmutable(-1234);
+        $bn3 = new BigNumberImmutable(0);
+        $bn4 = new BigNumberImmutable('-0.0000', 3);
+
+        $this->assertFalse($bn1->isNegative());
+        $this->assertTrue($bn2->isNegative());
+        $this->assertFalse($bn3->isNegative());
+        $this->assertFalse($bn4->isNegative());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::isPositive
+     */
+    public function testIsPositive()
+    {
+        $bn1 = new BigNumberImmutable(1234);
+        $bn2 = new BigNumberImmutable(-1234);
+        $bn3 = new BigNumberImmutable(0);
+        $bn4 = new BigNumberImmutable('-0.0000', 3);
+
+        $this->assertTrue($bn1->isPositive());
+        $this->assertFalse($bn2->isPositive());
+        $this->assertFalse($bn3->isPositive());
+        $this->assertFalse($bn4->isPositive());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::mod
+     */
+    public function testMod()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $mod = $bn->mod(3);
+
+        $this->assertNotSame($bn, $mod);
+        $this->assertSame('2', $mod->getValue());
+        $this->assertSame('0', $mod->mod(2)->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::mod
+     * @expectedException Moontoast\Math\Exception\ArithmeticException
+     * @expectedExceptionMessage Division by zero
+     */
+    public function testModDivisionByZero()
+    {
+        $bn = new BigNumberImmutable('9223372036854775808');
+        $bn->mod(0);
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::multiply
+     */
+    public function testMultiply()
+    {
+        $bn1 = new BigNumberImmutable('9223372036854775808.34747474747474747', 17);
+        $bn2 = new BigNumberImmutable('9223372036854775808.34747474747474747', 17);
+        $bn3 = new BigNumberImmutable('9223372036854775808.34747474747474747', 17);
+
+        $this->assertNotSame($bn1, $bn1->multiply(35));
+        $this->assertSame('322818021289917153292', $bn1->multiply(35)->withScale(0)->getValue());
+
+        $this->assertNotSame($bn2, $bn2->multiply(35));
+        $this->assertSame('322818021289917153292.161', $bn2->multiply(35)->withScale(3)->getValue());
+
+        $this->assertNotSame($bn3, $bn3->multiply(35));
+        $this->assertSame('322818021289917153292.16161616161616145', $bn3->multiply(35)->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::negate
+     */
+    public function testNegate()
+    {
+        $bn1 = new BigNumberImmutable(1234);
+        $bn2 = new BigNumberImmutable('0.000000567', 9);
+
+        $negative = $bn1->negate();
+        $this->assertSame('-1234', $negative->getValue());
+        $this->assertSame('1234', $negative->negate()->getValue());
+
+        $bn3 = $bn2->withScale(7);
+        $this->assertSame('-0.0000005', $bn3->negate()->getValue());
+
+        $bn4 = $bn2->withScale(6);
+        $this->assertSame('0.000000', $bn4->negate()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::pow
+     */
+    public function testPow()
+    {
+        $bn1 = new BigNumberImmutable(16);
+        $bn2 = new BigNumberImmutable('4294967296.5352423424523', 13);
+
+        $this->assertNotSame($bn1, $bn1->pow(8));
+        $this->assertSame('4294967296', $bn1->pow(8)->getValue());
+
+        $bn3 = $bn2->pow(2)->withScale(6);
+        $this->assertSame('18446744078307248328.820606', $bn3->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::powMod
+     */
+    public function testPowMod()
+    {
+        $bn1 = new BigNumberImmutable(16);
+
+        $this->assertNotSame($bn1, $bn1->powMod(8, 2));
+        $this->assertSame('0', $bn1->powMod(8, 2)->getValue());
+
+        $bn2 = $bn1->powMod(8, 2)->withScale(3);
+        $this->assertSame('0.000', $bn2->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::powMod
+     * @expectedException Moontoast\Math\Exception\ArithmeticException
+     * @expectedExceptionMessage Division by zero
+     */
+    public function testPowModDivisionByZero()
+    {
+        $bn = new BigNumberImmutable(16);
+        $bn->powMod(8, 0);
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::round
+     */
+    public function testRound()
+    {
+        $bn1 = new BigNumberImmutable('3.4', 1);
+        $bn2 = new BigNumberImmutable('3.5', 1);
+        $bn3 = new BigNumberImmutable('3.6', 1);
+        $bn4 = new BigNumberImmutable('1.95583', 5);
+        $bn5 = new BigNumberImmutable('1241757');
+        $bn6 = new BigNumberImmutable('-3.4', 1);
+        $bn7 = new BigNumberImmutable('-3.5', 1);
+        $bn8 = new BigNumberImmutable('-3.6', 1);
+
+        $this->assertSame('3', $bn1->round()->getValue());
+        $this->assertSame('4', $bn2->round()->getValue());
+        $this->assertSame('4', $bn3->round()->getValue());
+        $this->assertSame('2', $bn4->round()->getValue());
+        $this->assertSame('1241757', $bn5->round()->getValue());
+        $this->assertSame('-3', $bn6->round()->getValue());
+        $this->assertSame('-4', $bn7->round()->getValue());
+        $this->assertSame('-4', $bn8->round()->getValue());
+    }
+
+    public function testWithScaleWithValue()
+    {
+        $bn = new BigNumberImmutable(1);
+        $bn2 = $bn->withScale(2)->withValue(1234.657);
+
+        $this->assertSame('1234.65', $bn2->getValue());
+        $this->assertEquals(2, $bn2->getScale());
+    }
+
+    public function testWithValueWithScale()
+    {
+        $bn = new BigNumberImmutable(1);
+        $bn2 = $bn->withValue(1234.657)->withScale(2);
+        $this->assertSame('1234.00', $bn2->getValue());
+        $this->assertEquals(2, $bn2->getScale());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::signum
+     */
+    public function testSignum()
+    {
+        $bn1 = new BigNumberImmutable(1234);
+        $bn2 = new BigNumberImmutable(-1234);
+        $bn3 = new BigNumberImmutable(0);
+        $bn4 = new BigNumberImmutable('0.0000005', 7);
+        $bn5 = new BigNumberImmutable('-0.0000005', 7);
+
+        $this->assertEquals(1, $bn1->signum());
+        $this->assertEquals(-1, $bn2->signum());
+        $this->assertEquals(0, $bn3->signum());
+
+        $this->assertEquals(0, $bn4->withScale(0)->signum());
+
+        $this->assertEquals(1, $bn4->withScale(7)->signum());
+
+        $this->assertEquals(-1, $bn5->withScale(7)->signum());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::shiftLeft
+     */
+    public function testShiftLeft()
+    {
+        $bn = new BigNumberImmutable(1);
+
+        $this->assertSame($bn, $bn->shiftLeft(30));
+        $this->assertSame('1073741824', $bn->getValue());
+        $this->assertSame('4611686018427387904', $bn->shiftLeft(32)->getValue());
+        $this->assertSame('42535295865117307932921825928971026432', $bn->shiftLeft(63)->getValue());
+        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn->shiftLeft(64)->getValue());
+        $this->assertSame(
+            '3369993333393829974333376885877453834204643052817571560137951281152',
+            $bn->shiftLeft(32)->getValue()
+        );
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::shiftRight
+     */
+    public function testShiftRight()
+    {
+        $bn = new BigNumberImmutable('3369993333393829974333376885877453834204643052817571560137951281152');
+
+        $this->assertSame($bn, $bn->shiftRight(32));
+        $this->assertSame('784637716923335095479473677900958302012794430558004314112', $bn->getValue());
+        $this->assertSame('42535295865117307932921825928971026432', $bn->shiftRight(64)->getValue());
+        $this->assertSame('4611686018427387904', $bn->shiftRight(63)->getValue());
+        $this->assertSame('1073741824', $bn->shiftRight(32)->getValue());
+        $this->assertSame('1', $bn->shiftRight(30)->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::sqrt
+     */
+    public function testSqrt()
+    {
+        $bn1 = new BigNumberImmutable(16);
+        $bn2 = new BigNumberImmutable(17);
+        $bn3 = clone $bn2;
+
+        $this->assertSame($bn1, $bn1->sqrt());
+        $this->assertSame('4', $bn1->getValue());
+        $this->assertSame('4', $bn2->sqrt()->getValue());
+
+        $bn3->setScale(8);
+        $this->assertSame('4.12310562', $bn3->sqrt()->getValue());
+    }
+
+    /**
+     * @covers \Moontoast\Math\BigNumberImmutable::subtract
+     */
+    public function testSubtract()
+    {
+        $bn = new BigNumberImmutable(2147483647);
+
+        $this->assertSame($bn, $bn->subtract('9223372036854775808'));
+        $this->assertSame('-9223372034707292161', $bn->getValue());
+
+        $bn->setScale(3);
+        $this->assertSame('-9223372034707292163.250', $bn->subtract(2.25)->getValue());
+    }
+}

--- a/tests/Moontoast/Math/BigNumberImmutableTest.php
+++ b/tests/Moontoast/Math/BigNumberImmutableTest.php
@@ -622,4 +622,23 @@ class BigNumberImmutableImmutableTest extends TestCase
         $bn3 = $bn2->withScale(3);
         $this->assertSame('-9223372034707292163.250', $bn3->subtract(2.25)->getValue());
     }
+
+    public function testConstructorDoesntDirectlyWrapPassedMutableInstance()
+    {
+        $wrapped = new BigNumber(1);
+        $SUT = new BigNumberImmutable($wrapped);
+        $wrapped->setValue(2);
+        static::assertNotEquals($wrapped->getValue(), $SUT->getValue());
+        static::assertSame("2", $wrapped->getValue());
+        static::assertSame("1", $SUT->getValue());
+    }
+
+    public function testConstructorDoesUpdate0ScaleWithPassedMutableInstance()
+    {
+        $wrapped = new BigNumber(1, 2);
+        $SUT = new BigNumberImmutable($wrapped, 0);
+        static::assertNotSame($wrapped->getValue(), $SUT->getValue());
+        static::assertSame(0, $SUT->getScale());
+        static::assertSame("1", $SUT->getValue());
+    }
 }


### PR DESCRIPTION
This is a BC safe implementation of a `BigNumberImmutable` class.

This pr does the follow:
- introduce a `BigNumberInterface`
- introduce an `AbstractBigNumber` implementing it, to extract common code (mainly convenience and static methods).
- introduce a `BigNumberImmutable`, extending `AbstractBigNumber` and composing a mutable `BigNumber`.
- make `BigNumber` extend `AbstractBigNumber`.

There is a subtle difference in how `BigNumberImmutable` works in respect to `BigNumber` when using `withScale` method instead of `setScale`:

When invoking `BigNumberImmutable::withScale()`, the new instance will have the new value re-computed according to the new scale. With `BigNumber::setScale()` instead, the change doesn't happen until subsequent computations.

Here is a more explanatory example:
```php
$bn = new BigNumberImmutable(1.0001, 4);
assert("1.0001" === $bn->getValue());
$bn = $bn->WithScale(2);
assert("1.00" === $bn->getValue());

$bn = new BigNumber(1.0001, 4);
assert("1.0001" === $bn->getValue());
$bn->setScale(2);
assert("1.0001" === $bn->getValue());
$bn->add(0);
assert("1.00" === $bn->getValue());
```

I think `BigNumberImmutable` behaviour is more coherent and predictable.